### PR TITLE
Fix Linux binaries

### DIFF
--- a/recipe/meson-rpaths.patch
+++ b/recipe/meson-rpaths.patch
@@ -1,0 +1,27 @@
+diff --git a/lib/meson.build b/lib/meson.build
+index e3691d1..73b09b1 100644
+--- a/lib/meson.build
++++ b/lib/meson.build
+@@ -78,4 +78,6 @@ libfribidi = library('fribidi',
+   c_args: ['-DHAVE_CONFIG_H'] + visibility_args,
+   version: libversion,
+   soversion: soversion,
+-  install: true)
++  install: true,
++  install_rpath: join_paths(get_option('prefix'), get_option('libdir'))
++)
+diff --git a/bin/meson.build b/bin/meson.build
+index 823ed02..e039920 100644
+--- a/bin/meson.build
++++ b/bin/meson.build
+@@ -3,7 +3,9 @@ fribidi = executable('fribidi',
+   c_args: ['-DHAVE_CONFIG_H'],
+   include_directories: incs,
+   link_with: libfribidi,
+-  install: true)
++  install: true,
++  install_rpath: join_paths(get_option('prefix'), get_option('libdir'))
++)
+ 
+ executable('fribidi-benchmark',
+   'fribidi-benchmark.c', 'getopt.c', 'getopt1.c', fribidi_unicode_version_h,

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,9 +8,11 @@ package:
 source:
    url: https://github.com/fribidi/fribidi/releases/download/v{{ version }}/fribidi-{{ version }}.tar.bz2
    sha256: {{ sha256 }}
+   patches:
+     - meson-rpaths.patch
 
 build:
-  number: 1001
+  number: 1002
   skip: true  # [win]
   run_exports:
     - {{ pin_subpackage('fribidi') }}


### PR DESCRIPTION
We ran into another instance of conda-forge/glib-feedstock#40 AKA mesonbuild/meson#4685, in which Meson edits the rpaths of the binaries it installs in a way that breaks future `ldconfig` invocations. From previous investigations, setting an `install_rpath` for the installed binaries avoids the issue, so let's do that.

* [x] Used a fork of the feedstock to propose changes
* [x] Bumped the build number (the version is unchanged)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

(That instance was conda-forge/pango-feedstock#24 — the aarch64 shared library binary was breaking things.)

**edit**: Local testing indicates that this change indeed fixes the problem.